### PR TITLE
Convert json properties to UCFirst.

### DIFF
--- a/dev/jquery.jtable.core.js
+++ b/dev/jquery.jtable.core.js
@@ -401,6 +401,11 @@
         /* Performs an AJAX call to reload data of the table.
         *************************************************************************/
         _reloadTable: function (completeCallback) {
+            for(var key in data) {
+                data[key.charAt(0).toUpperCase() + key.slice(1).toLowerCase()] = data[key];
+                delete(data[key]);
+            }
+    
             var self = this;
 
             var completeReload = function(data) {


### PR DESCRIPTION
I had problems with jsons like

    {
      result: "OK",
      records: []
    }

because the first characters were lowercase. The fix converts the incoming json properties (only 1st level!!) to UCFirst to fit the requirements of JTable.
