### PR TITLE
Update jquery.jtable.zh-CN.js

### DIFF
--- a/lib/localization/jquery.jtable.zh-CN.js
+++ b/lib/localization/jquery.jtable.zh-CN.js
@@ -23,8 +23,8 @@
         pagingInfo: '显示 {0} 至 {1} 共 {2}',
         canNotDeletedRecords: '删除失败 {0} 至 {1}!',
         deleteProggress: '正在删除 {0} 至 {1} 记录, 进心中...',
-        pageSizeChangeLabel: 'Row count', //New. Must be localized.
-        gotoPageLabel: 'Go to page' //New. Must be localized.
+        pageSizeChangeLabel: '行数', 
+        gotoPageLabel: '翻到(页)' 
     });
 
 })(jQuery);


### PR DESCRIPTION
localized 'Row Count' and 'Go to Page'
and in Chinese People like to say :'Go to nth Page' not 'Go to page nth'.
I remember jqGrid or something has a solution for this diff.